### PR TITLE
1-4 edits and 5-3 exponent fix

### DIFF
--- a/source/exercises/doenet/ez-1-4-D-2.doenetml
+++ b/source/exercises/doenet/ez-1-4-D-2.doenetml
@@ -193,14 +193,14 @@ The graph of a piecewise function  <m>f(x)</m> with three linear pieces is given
 <p>
   Complete the following sentence using drop-down menus to explain the behavior of the graph of the derivative function.
 </p>
-<p>Because the original function is piecewise linear, on corresponding intervals the slope of the tangent line to <m>f</m> <answer><choiceInput inline>
+<p>Because the original function is piecewise linear, on corresponding intervals the slope of the tangent line to <m>f</m> <choiceInput name="r1" inline>
       <choice>is changing</choice>
       <choice credit="1">is not changing</choice>
-    </choiceInput></answer>, which means that on those same intervals, the graph of the derivative function consists of <answer><choiceInput inline>
+    </choiceInput>, which means that on those same intervals, the graph of the derivative function consists of <choiceInput name="r2" inline>
       <choice credit="1">horizontal line segments.</choice>
       <choice>line segments that are rising or falling.</choice>
       <choice>curved pieces.</choice>
-    </choiceInput></answer>
+    </choiceInput><answer><award><when>$r1.selectedIndices=2 and $r2.selectedIndices=1</when></award></answer>
 
     </p>
 

--- a/source/exercises/doenet/ez-1-4-D-2.doenetml
+++ b/source/exercises/doenet/ez-1-4-D-2.doenetml
@@ -34,16 +34,16 @@
 </setup>
 
 
-The graph of a piecewise function  <m>f(x)</m> with three linear pieces is given by the following graph.  
+The graph of a piecewise function  <m>f(x)</m> with three linear pieces is given by the following graph.
 
 <graph xmin="-3.5" xmax="7" ymin="-3" ymax="8"  showNavigation="false" fixAxes="true" grid>
 
   <polyline name="polyline1" fixed vertices="(-3,1) (0,2.5) (3,-2) (6,7)" />
 
-  <label anchor="(5.5,2.7)"> 
+  <label anchor="(5.5,2.7)">
     <m>y=f(x)</m>
   </label>
-  
+
   <point styleNumber="2">(0,0)
     <constraints><constrainTo>$polyline1</constrainTo></constraints>
   </point>
@@ -57,28 +57,28 @@ The graph of a piecewise function  <m>f(x)</m> with three linear pieces is given
     <p>
       For each of the three linear pieces, pick two points on the graph, estimate their coordinates, and from those coordinates estimate the slope of that line.  Note that you can drag the moveable point on the graph to see estimates of the coordinates of different points on each segment.  Report your three slopes in the provided spaces below, doing so to an accuracy of at least 0.1.
     </p>
-  
+
     <p>
-      Slope of left segment: 
+      Slope of left segment:
       <answer>
       <award symbolicEquality='true' allowedErrorInNumbers='0.1' allowedErrorIsAbsolute="true" simplifyOnCompare='numbers'>$m1 </award>
       </answer>
     </p>
     <p>
-      Slope of middle segment: 
+      Slope of middle segment:
       <answer>
       <award symbolicEquality='true' simplifyOnCompare='numbers' allowedErrorInNumbers='0.1' allowedErrorIsAbsolute="true">$m2 </award>
-      </answer> 
+      </answer>
     </p>
     <p>
-      Slope of right segment: 
+      Slope of right segment:
       <answer>
       <award simplifyOnCompare='numbers' symbolicEquality='true' allowedErrorInNumbers='0.1' allowedErrorIsAbsolute="true">$m3 </award>
-      </answer> 
+      </answer>
     </p>
 
-<!-- 
-<p>Should your estimate of the slope depend on your choice of points? 
+<!--
+<p>Should your estimate of the slope depend on your choice of points?
 <answer inline='true'>
 <choiceInput>
 <choice credit='1'>no</choice>
@@ -93,27 +93,27 @@ The graph of a piecewise function  <m>f(x)</m> with three linear pieces is given
   <li>
     <p>
         Remember that the derivative of any linear function is precisely the value of the linear function's slope.  For each linear piece of the function that you considered in (a), what is the derivative of <m>f(x)</m>?  Report your answers to an accuracy of at least 0.1.
-    </p>  
+    </p>
 
-  
+
     <p>
-      <m>f'(x)</m> for left segment: 
+      <m>f'(x)</m> for left segment:
         <answer>
           <award symbolicEquality='true' simplifyOnCompare='numbers' allowedErrorInNumbers='0.1' allowedErrorIsAbsolute="true">$m1 </award>
         </answer>
     </p>
     <p>
-      <m>f'(x)</m> for middle segment: 
+      <m>f'(x)</m> for middle segment:
       <answer>
         <award symbolicEquality='true' simplifyOnCompare='numbers' allowedErrorInNumbers='0.1' allowedErrorIsAbsolute="true">$m2 </award>
       </answer>
     </p>
     <p>
-      <m>f'(x)</m> for right segment: 
+      <m>f'(x)</m> for right segment:
       <answer>
         <award symbolicEquality='true' simplifyOnCompare='numbers' allowedErrorInNumbers='0.1' allowedErrorIsAbsolute="true">$m3 </award>
       </answer>
-    
+
     </p>
   </li>
 
@@ -121,91 +121,89 @@ The graph of a piecewise function  <m>f(x)</m> with three linear pieces is given
     <p>
       Sketch the derivative of <m>f</m>.  Drag the points so that each <!-- <copy prop="styleDescription" tname="derivSeg1" /> --> line segment corresponds to the corresponding segment of the original function.
     </p>
-    
+
     <graph xmin="-3.5" xmax="7" ymin="-3" ymax="8" showNavigation="false" fixAxes="true" grid>
-    
+
 <!--  <copy tname='polyline1' /> -->
       $polyline1
-    
+
     <point styleNumber="6" name="p1" x="$x1" y="2">
       <constraints>
         <constrainToGrid dy="0.5"/>
       </constraints>
     </point>
-    
+
     <point styleNumber="6" name="p2" x="$x2" y="3">
       <constraints>
         <constrainToGrid dy="0.5"/>
       </constraints>
     </point>
-    
+
     <lineSegment name="derivSeg1" styleNumber="2" endpoints="$p1 $p2" />
-        
+
     <point styleNumber="6" name="p3" x="$x2" y="-1">
       <constraints>
         <constrainToGrid dy="0.5"/>
       </constraints>
     </point>
-    
+
     <point styleNumber="6" name="p4" x="$x3" y="1">
       <constraints>
         <constrainToGrid dy="0.5"/>
       </constraints>
     </point>
-    
+
     <lineSegment styleNumber="2" endpoints="$p3 $p4" />
-    
-    
+
+
     <point styleNumber="6" name="p5" x="$x3" y="4">
       <constraints>
         <constrainToGrid dy="0.5"/>
       </constraints>
     </point>
-    
+
     <point styleNumber="6" name="p6" x="$x4" y="4">
       <constraints>
         <constrainToGrid dy="0.5"/>
       </constraints>
     </point>
-    
+
     <lineSegment stylenumber="2" endpoints="$p5 $p6" />
-    
+
   </graph>
 
     <!--
   <p>
-    <math>($p1.y-$p2.y)/($p1.x-$p2.x) </math>; <math>$m1</math>; 
+    <math>($p1.y-$p2.y)/($p1.x-$p2.x) </math>; <math>$m1</math>;
     $slope1
-  </p>  
+  </p>
     -->
-    
-  <answer>
-    <award><when>
-      <boolean> 
-        $p1.y = $m1 and $p2.y = $m1
+
+  <answer name="derivpiecewise">
+    <award><when matchPartial>
+        <boolean>$p1.y = $m1 and $p2.y = $m1</boolean>
         and
-        $p3.y = $m2 and $p4.y = $m2
+        <boolean>$p3.y = $m2 and $p4.y = $m2</boolean>
         and
-        $p5.y = $m3 and $p6.y = $m3 
-      </boolean>      
+        <boolean>$p5.y = $m3 and $p6.y = $m3</boolean>
     </when></award>
   </answer>
-  
-  <hint>
-    <p>For each segment of the function, is the slope constant or does it change? 
-    <answer weight="0"><choiceInput inline>
-      <choice credit="1">constant</choice>
-      <choice>changing</choice>
+
+
+<p>
+  Complete the following sentence using drop-down menus to explain the behavior of the graph of the derivative function.
+</p>
+<p>Because the original function is piecewise linear, on corresponding intervals the slope of the tangent line to <m>f</m> <answer><choiceInput inline>
+      <choice>is changing</choice>
+      <choice credit="1">is not changing</choice>
+    </choiceInput></answer>, which means that on those same intervals, the graph of the derivative function consists of <answer><choiceInput inline>
+      <choice credit="1">horizontal line segments.</choice>
+      <choice>line segments that are rising or falling.</choice>
+      <choice>curved pieces.</choice>
     </choiceInput></answer>
-    Therefore, each segment that you draw should be
-      <answer weight="0"><choiceInput inline>
-      <choice>vertical</choice>
-      <choice>rising or falling</choice>
-      <choice credit="1">horizontal</choice>
-    </choiceInput></answer>.
+
     </p>
-  </hint>
-    
+
   </li>
 
   <li>
@@ -220,47 +218,47 @@ The graph of a piecewise function  <m>f(x)</m> with three linear pieces is given
           <choice><m>f'(0)=-1.5</m></choice>
     </choiceInput></answer>
     </p>
-  </li>  
-  
+  </li>
+
 </ol>
 
 <!--
   <solution>
-  
-  
+
+
   <ol>
-  
+
   <li>
   Many sets of points would do.  The slopes, from left to right, are <round numberdecimals="1">$m1  </round>, <round numberdecimals="1">$m2  </round>, and <round numberdecimals="1">$m3  </round>.  The estimates should not depend on choice of points as long as both points are on the same segment.
   </li>
-  
+
   <li>
   The derivatives would be <round numberdecimals="1">$m1  </round>, <round numberdecimals="1">$m2  </round>, and <round numberdecimals="1">$m3  </round>, for the three segments, respectively.
   </li>
-  
+
   <li>
-  
+
   <graph xmin='-3.5' xmax='7' ymin='-3' ymax='8' xlabel='x' ylabel='f(x)' showNavigation="false" fixAxes="true">
-  
+
   <copy tname='polyline1' />
-  
+
   <point stylenumber="2" fixed>($x1,$m1)</point>
   <point stylenumber="2" fixed>($x2,$m1)</point>
   <point stylenumber="2" fixed>($x2,$m2)</point>
   <point stylenumber="2" fixed>($x3,$m2)</point>
   <point stylenumber="2" fixed>($x3,$m3)</point>
   <point stylenumber="2" fixed>($x4,$m3)</point>
-  
+
   <linesegment stylenumber="2" fixed endpoints="($x1, $m1) ($x2, $m1)" />
   <linesegment stylenumber="2" fixed endpoints="($x2, $m2) ($x3, $m2)" />
   <linesegment stylenumber="2" fixed endpoints="($x3, $m3) ($x4, $m3)" />
-  
+
   </graph>
-  
+
   </li>
-  
-  
+
+
   </ol>
-  
+
   </solution>
 -->

--- a/source/exercises/doenet/ez-1-4-D-6.doenetml
+++ b/source/exercises/doenet/ez-1-4-D-6.doenetml
@@ -14,11 +14,11 @@
 
 <setup>
 <selectFromSequence name="a" from="2" to="5"/>
-<selectFromSequence name="c" from="-3" to="3" exclude="0"/>  
+<selectFromSequence name="c" from="-3" to="3" exclude="0"/>
 <function name="f">
     $c + $a*x - x^2
   </function>
-  <derivative name="fP">$f</derivative>  
+  <derivative name="fP">$f</derivative>
 </setup>
 
   <p>
@@ -32,16 +32,18 @@
           and thus we need to determine expressions for <m>f(x+h)</m> and <m>f(x+h) - f(x)</m>.
         </p>
 
-        <p>Using the given formula, <m>f(x) = $f</m>, 
-      which of the following expressions is equivalent to <m>f(x+h)</m>?</p>
+        <p>Using the given formula, <m>f(x) = $f</m>,
+      select all of the following expressions which are equivalent to <m>f(x+h)</m>. The correct answer involves selecting more than one of the following items.</p>
             <answer>
-              <choiceInput>
-                <choice><m>f(x+h) = $c - $a(x+h) + (x+h)^2 </m></choice>
-                <choice><m>f(x+h)= $c + <math>$a*h</math> + h^2 + ($a+2x)h - x^2 </m>  </choice>
-                <choice credit="1"><m>f(x+h)= $c + <math>$a*h</math> - h^2 + ($a-2x)h - x^2 </m>  </choice>          
-                <choice><m>f(x+h)= $c + <math>$a*h</math> - h^2 + (1-2x)h - x^2 </m>  </choice>
+              <choiceInput selectMultiple>
+                <choice><m>f(x+h) = $c + <math>$a*x</math> - x^2 + h </m></choice>
+                <choice><m>f(x+h) = $c + $a(x+h) - (x^2 + h^2) </m></choice>
+                <choice credit="1"><m>f(x+h) = $c + $a(x+h) - (x+h)^2 </m></choice>
+                <choice credit="1"><m>f(x+h)= $c + <math>$a*x+$a*h</math> - (x^2 + 2xh + h^2) </m>  </choice>
+                <choice ><m>f(x+h)= $c + <math>$a*x +$a*h</math> -x^2 + 2xh + h^2 </m>  </choice>
+                <choice credit="1"><m>f(x+h)= $c + <math>$a*x-x^2 +$a*h</math> - 2xh - h^2 </m>  </choice>
               </choiceInput>
-            </answer>  
+            </answer>
       </li>
       <li>
       <p>Which of the following is the simplest possible expression for <m>f(x+h) - f(x)</m>?</p>
@@ -49,24 +51,24 @@
               <choiceInput>
                 <choice><m>f(x+h) - f(x) = $a(x+h)-(x+h)^2 + <math simplify>-1*$$f(x)</math> </m></choice>
                 <choice><m>f(x+h) - f(x) =  - h^2 + <math simplify>$a*h </math></m>  </choice>
-                <choice><m>f(x+h) - f(x) =  <math>$a*h</math> + h^2 - 2xh</m>  </choice>  
-                <choice credit="1"><m>f(x+h)  - f(x) =  <math>$a*h</math> - h^2 - 2xh</m>  </choice> 
+                <choice><m>f(x+h) - f(x) =  <math>$a*h</math> + h^2 - 2xh</m>  </choice>
+                <choice credit="1"><m>f(x+h)  - f(x) =  <math>$a*h</math> - h^2 - 2xh</m>  </choice>
               </choiceInput>
-            </answer>   
+            </answer>
       </li>
-      <li> 
+      <li>
         <p>
           Next, apply the limit definition of the derivative by substituting the simplest possible expression for <m>f(x+h)-f(x)</m> in the space provided:
         </p>
         <p><m>f'(x)= \displaystyle \lim_{h \to 0} \frac{f(x+h)-f(x)}{h} = \lim_{h \to 0} </m> <mathInput name="dq_x1" prefill="/h"></mathInput>
-      <answer><award><when>$dq_x1 = 
+      <answer><award><when>$dq_x1 =
         ($$f(x+h) - $$f(x))/h
       </when></award></answer></p>
       </li>
       <li>
         <p>Further, factoring the numerator and simplifying the quotient as much as possible, we see that</p>
         <p>  <m>f'(x)= \displaystyle \lim_{h \to 0} </m> <mathInput name="simp_x1"></mathInput>
-      <answer><award><when>$simp_x1 = 
+      <answer><award><when>$simp_x1 =
         ($$f(x+h) - $$f(x))/h
       </when></award></answer></p>
       </li>

--- a/source/exercises/doenet/ez-5-3-D-7.doenetml
+++ b/source/exercises/doenet/ez-5-3-D-7.doenetml
@@ -27,41 +27,130 @@
   <function name="uSubs" variable="u">$a/$k*u^$p</function>
   <function name="antiDu" variable="u">$a/$k*1/($p+1)*u^($p+1)</function>
 
-  <boolean name="uSubsFound">$uSubs = $uSubsChoice</boolean>
+  <!-- <boolean name="uSubsFound">$uSubs = $uSubsChoice</boolean> -->
+  <boolean name="uSubsFound">$usubsequals.creditAchieved</boolean>
+
+   <!-- For checking whether or not they made a choice from the dropdown menus in order to give targeted feedback. -->
+   <boolean name="choseduordx1">$duordx1.selectedIndices=2 or $duordx1.selectedIndices=3</boolean>
+   <!-- The line below is used when there's an additional step asked for. -->
+  <!-- <boolean name="choseduordx2">$duordx2.selectedIndices=2 or $duordx2.selectedIndices=3</boolean>  -->
+  <boolean name="choseduordx3">$duordx3.selectedIndices=2 or $duordx3.selectedIndices=3</boolean>
+  <boolean name="choseduordxorC1">$duordxorC1.selectedIndices=2 or $duordxorC1.selectedIndices=3 or $duordxorC1.selectedIndices=4</boolean>
+  <boolean name="choseduordxorC2">$duordxorC2.selectedIndices=2 or $duordxorC2.selectedIndices=3 or $duordxorC2.selectedIndices=4</boolean>
+
+<!-- For checking for the presence of a specific variable in their answers in order to give targeted feedback. -->
+   <derivative name="dantiDxChoicedu" variable="u">
+     $antiDxChoice
+   </derivative>
+   <derivative name="dantiDxChoicedx" variable="x">
+     $antiDxChoice
+   </derivative>
+   <derivative name="dantiDuChoicedx" variable="x">
+     $antiDuChoice
+   </derivative>
+   <derivative name="dantiDuChoicedu" variable="u">
+     $antiDuChoice
+   </derivative>
 
 </setup>
 
 <p>
-  Consider the indefinite integral <m>\int $a (\sec($k x))^2 ($b + \tan($k x))^{$p} \, dx</m>, which can be evaluated using <m>u</m>-substitution.
+  Consider the indefinite integral <m>\displaystyle \int $a (\sec($k x))^2 ($b + \tan($k x))^{$p} \, dx</m>, which can be evaluated using <m>u</m>-substitution.
 </p>
 <p>
-  Find an appropriate composite function present in the integrand and choose the corresponding inner function for <m>u</m>, and then find <m>du</m> as well.  Fill in the following blanks to state both <m>u</m> and <m>du</m> as functions of <m>x</m>.
+  Find an appropriate composite function present in the integrand and choose the corresponding inner function for <m>u</m>, and then find <m>du</m> as well. Fill in the following blank to state <m>u</m> as a function of <m>x</m> and then calculate <m>du</m>. Note that the dropdown is part of your answer.
 </p>
-
 <p>
   <m>u = </m><mathInput name="uChoice"/> <answer><award><when>$uChoice = $u</when></award></answer>
 </p>
 <p>
-  <m>du = </m><mathInput name="duChoice"/><m>dx</m> <answer><award><when>$duChoice = $du</when></award></answer>
+  <m>du = </m><mathInput name="duChoice"/><choiceInput name="duordx1" inline>
+            <choice>?</choice>
+            <choice><m>dx</m></choice>
+            <choice><m>du</m></choice>
+          </choiceInput>
+    <m> =</m> <mathInput disabled> $duChoice $duordx1 </mathInput>
+  <answer name="duequals"><award><when>$duChoice = $du and $duordx1.selectedIndices=2</when></award></answer>
 </p>
+<feedback condition = "$duequals.justSubmitted and !$choseduordx1">You must pick <m>du</m> or <m>dx</m>.</feedback>
+<feedback condition = "$duChoice = $du and $duordx1.selectedIndices!=2 and $duequals.justSubmitted and $choseduordx1">You still need to correctly pick <m>du</m> or <m>dx</m>.</feedback>
+<feedback condition = "$duChoice != $du and $duordx1.selectedIndices=2 and $duequals.justSubmitted">You have the incorrect derivative, but <m>dx</m> is correct.</feedback>
 
 <p>
     Now we can apply <m>u</m>-substitution to convert the original integral in <m>x</m> to a simpler integral in <m>u</m>.  Using our work above, we have
 </p>
 <p>
-  <m>\int $a (\sec($k x))^2 ($b + \tan($k x))^{$p} \, dx = \int </m> <mathInput name="uSubsChoice"/> <m>\, du</m> <answer><award><when> $uSubs = $uSubsChoice</when></award></answer>
+  <m>\displaystyle \int $a (\sec($k x))^2 ($b + \tan($k x))^{$p} \, dx = \int </m> <mathInput name="uSubsChoice"/><choiceInput name="duordx3" inline>
+            <choice>?</choice>
+            <choice><m>dx</m></choice>
+            <choice><m>du</m></choice>
+          </choiceInput>
+  <answer name="usubsequals"><award><when> $uSubs = $uSubsChoice and $duordx3.selectedIndices=3</when></award></answer>
 </p>
+<p>
+    <m> = \displaystyle \int</m><mathInput disabled> $uSubsChoice $duordx3 </mathInput>
+
+</p>
+<feedback condition = "$usubsequals.justSubmitted and !$choseduordx3">You must pick <m>du</m> or <m>dx</m>.</feedback>
+<feedback condition = "$uSubs = $uSubsChoice and $duordx3.selectedIndices!=3 and $usubsequals.justSubmitted and $choseduordx3">You still need to correctly pick <m>du</m> or <m>dx</m>.</feedback>
+<feedback condition = "$uSubs != $uSubsChoice and $duordx3.selectedIndices=3 and $usubsequals.justSubmitted">You have the incorrect formula, but <m>du</m> is correct.</feedback>
 
 <p hide="$uSubsFound">
   (<em>A final sequence of prompts will appear here after you correctly execute the <m>u</m>-substitution in the last step above.</em>)
 </p>
-<p hide="not $uSubsFound">
+<div hide="not $uSubsFound">
   <p>
     Finally, we evaluate the simpler integral in <m>u</m> and then substitute back to write our final result in terms of <m>x</m>.
   </p>
   <p>
-  <m>\int $a (\sec($k x))^2 ($b + \tan($k x))^{$p} \, dx = \int $uSubsChoice \, du</m> = <mathInput name="antiDuChoice"/> <m>+ C</m> <answer simplifyOnCompare><award><when> $antiDu = $antiDuChoice</when></award></answer> <m> = </m> <mathInput name="antiDxChoice"/> <m>+ C</m> <answer simplifyOnCompare><award><when> $antiDx = $antiDxChoice</when></award></answer>.
-</p>
+  <m>\displaystyle\int $a (\sec($k x))^2 ($b + \tan($k x))^{$p} \, dx = \int $uSubsChoice \, du</m> = <mathInput name="antiDuChoice"/><choiceInput name="duordxorC1" inline>
+            <choice>?</choice>
+            <choice><m>dx</m></choice>
+            <choice><m>du</m></choice>
+            <choice><m>+C</m></choice>
+          </choiceInput>
+  </p>
+  <p>
+    <m>=</m><mathInput disabled><conditionalContent>
+  <case condition="$duordxorC1.selectedIndices !=4">
+    <math name="displayantiDuequals">$antiDuChoice $duordxorC1</math>
+  </case>
+  <case condition="$duordxorC1.selectedIndices = 4">
+    <math name="displayantiDuequals">$antiDuChoice + C</math>
+  </case>
+</conditionalContent></mathInput>
+  <answer name="antiDuequals"><award><when> $antiDu = $antiDuChoice and $duordxorC1.selectedIndices=4</when></award></answer>
+  </p>
 
+<feedback condition = "$antiDuequals.justSubmitted and !$choseduordxorC1">You must pick <m>du</m> or <m>dx</m> or <m>+C</m>.</feedback>
+<feedback condition = "$duordxorC1.selectedIndices!=4 and $antiDuequals.justSubmitted and $choseduordxorC1">Recall that <m>du</m> and <m>dx</m> are part of an integral, and you've just evaluated an indefinite integral.</feedback>
+<feedback condition = "$antiDu != $antiDuChoice and $dantiDuChoicedx =0 and $duordxorC1.selectedIndices=4 and $antiDuequals.justSubmitted">You have the incorrect formula, but <m>+C</m> is correct.</feedback>
+<feedback condition = "$dantiDuChoicedx*0=0 and $dantiDuChoicedx !=0 and $duordxorC1.selectedIndices=4 and $antiDuequals.justSubmitted">Your answer should be in terms of <m>u</m> and not <m>x</m>, but <m>+C</m> is correct.</feedback>
+<feedback condition = "$dantiDuChoicedx*0!=0 and $dantiDuChoicedu*0!=0 and $duordxorC1.selectedIndices=4 and $antiDuequals.justSubmitted">The <m>+C</m> is correct.</feedback>
+  <p>
+    <m> = </m> <mathInput name="antiDxChoice"/><choiceInput name="duordxorC2" inline>
+            <choice>?</choice>
+            <choice><m>dx</m></choice>
+            <choice><m>du</m></choice>
+            <choice><m>+C</m></choice>
+          </choiceInput>
+  </p>
+  <p>
+    <m>=</m><mathInput disabled><conditionalContent>
+  <case condition="$duordxorC2.selectedIndices !=4">
+    <math name="displayantiDxequals">$antiDxChoice $duordxorC2</math>
+  </case>
+  <case condition="$duordxorC2.selectedIndices = 4">
+    <math name="displayantiDxequals">$antiDxChoice + C</math>
+  </case>
+</conditionalContent></mathInput>
+  <answer name="antiDxequals"><award><when> $antiDx = $antiDxChoice and $duordxorC2.selectedIndices=4</when></award></answer>
+  </p>
 
-</p>
+<feedback condition = "$antiDxequals.justSubmitted and !$choseduordxorC2">You must pick <m>du</m> or <m>dx</m> or <m>+C</m>.</feedback>
+<feedback condition = "$duordxorC2.selectedIndices!=4 and $antiDxequals.justSubmitted and $choseduordxorC2">Recall that <m>du</m> and <m>dx</m> are part of an integral, and you've just evaluated an indefinite integral.</feedback>
+<feedback condition = "$antiDx != $antiDxChoice and $dantiDxChoicedu =0 and $duordxorC2.selectedIndices=4 and $antiDxequals.justSubmitted">You have the incorrect formula, but <m>+C</m> is correct.</feedback>
+<feedback condition = "$dantiDxChoicedu*0=0 and $dantiDxChoicedu !=0 and $duordxorC2.selectedIndices=4 and $antiDxequals.justSubmitted">Your answer should be in terms of <m>x</m> and not <m>u</m>, but <m>+C</m> is correct.</feedback>
+<feedback condition = "$dantiDxChoicedx*0!=0 and $dantiDxChoicedu*0!=0 and $duordxorC2.selectedIndices=4 and $antiDxequals.justSubmitted">The <m>+C</m> is correct.</feedback>
+
+</div>   

--- a/source/exercises/doenet/ez-5-3-D-7.doenetml
+++ b/source/exercises/doenet/ez-5-3-D-7.doenetml
@@ -15,7 +15,7 @@
  <setup>
   <selectFromSequence name = "k" from = "8" to = "10" step = "1"/>
   <selectFromSequence name = "a" from = "5" to = "10" step = "1" exclude="$k ($k-1)"/>
-  <selectFromSequence name = "p" from = "4" to = "10" step = "1" exclude="$k ($k-1) $a"/>   
+  <selectFromSequence name = "p" from = "4" to = "10" step = "1" exclude="$k ($k-1) $a"/>
   <selectFromSequence name = "b" from = "3" to = "8" step = "1" exclude="$k $a ($k-1) ($k+1) $p"/>
 
   <function name="c">$a*(sec($k*x))^2*($b + tan($k*x))^$p</function>
@@ -28,29 +28,29 @@
   <function name="antiDu" variable="u">$a/$k*1/($p+1)*u^($p+1)</function>
 
   <boolean name="uSubsFound">$uSubs = $uSubsChoice</boolean>
-   
+
 </setup>
 
 <p>
-  Consider the indefinite integral <m>\int $a (\sec($k x))^2 ($b + \tan($k x))^$p \, dx</m>, which can be evaluated using <m>u</m>-substitution.  
+  Consider the indefinite integral <m>\int $a (\sec($k x))^2 ($b + \tan($k x))^{$p} \, dx</m>, which can be evaluated using <m>u</m>-substitution.
 </p>
-<p>  
+<p>
   Find an appropriate composite function present in the integrand and choose the corresponding inner function for <m>u</m>, and then find <m>du</m> as well.  Fill in the following blanks to state both <m>u</m> and <m>du</m> as functions of <m>x</m>.
-</p>  
+</p>
 
 <p>
   <m>u = </m><mathInput name="uChoice"/> <answer><award><when>$uChoice = $u</when></award></answer>
-</p> 
-<p>
-  <m>du = </m><mathInput name="duChoice"/><m>dx</m> <answer><award><when>$duChoice = $du</when></award></answer>
-</p>  
-
-<p>
-    Now we can apply <m>u</m>-substitution to convert the original integral in <m>x</m> to a simpler integral in <m>u</m>.  Using our work above, we have 
 </p>
 <p>
-  <m>\int $a (\sec($k x))^2 ($b + \tan($k x))^$p \, dx = \int </m> <mathInput name="uSubsChoice"/> <m>\, du</m> <answer><award><when> $uSubs = $uSubsChoice</when></award></answer>
-</p>  
+  <m>du = </m><mathInput name="duChoice"/><m>dx</m> <answer><award><when>$duChoice = $du</when></award></answer>
+</p>
+
+<p>
+    Now we can apply <m>u</m>-substitution to convert the original integral in <m>x</m> to a simpler integral in <m>u</m>.  Using our work above, we have
+</p>
+<p>
+  <m>\int $a (\sec($k x))^2 ($b + \tan($k x))^{$p} \, dx = \int </m> <mathInput name="uSubsChoice"/> <m>\, du</m> <answer><award><when> $uSubs = $uSubsChoice</when></award></answer>
+</p>
 
 <p hide="$uSubsFound">
   (<em>A final sequence of prompts will appear here after you correctly execute the <m>u</m>-substitution in the last step above.</em>)
@@ -60,8 +60,8 @@
     Finally, we evaluate the simpler integral in <m>u</m> and then substitute back to write our final result in terms of <m>x</m>.
   </p>
   <p>
-  <m>\int $a (\sec($k x))^2 ($b + \tan($k x))^$p \, dx = \int $uSubsChoice \, du</m> = <mathInput name="antiDuChoice"/> <m>+ C</m> <answer simplifyOnCompare><award><when> $antiDu = $antiDuChoice</when></award></answer> <m> = </m> <mathInput name="antiDxChoice"/> <m>+ C</m> <answer simplifyOnCompare><award><when> $antiDx = $antiDxChoice</when></award></answer>.  
-</p>  
+  <m>\int $a (\sec($k x))^2 ($b + \tan($k x))^{$p} \, dx = \int $uSubsChoice \, du</m> = <mathInput name="antiDuChoice"/> <m>+ C</m> <answer simplifyOnCompare><award><when> $antiDu = $antiDuChoice</when></award></answer> <m> = </m> <mathInput name="antiDxChoice"/> <m>+ C</m> <answer simplifyOnCompare><award><when> $antiDx = $antiDxChoice</when></award></answer>.
+</p>
 
-  
-</p>  
+
+</p>


### PR DESCRIPTION
Changed exercise 1-4-D-2 to move the dropdowns out of the hint and also give partial credit on the graph; changed part a of 1-4-D-6 to become multiple select (and thereby also fix a mistake), and in 5-3-D-7 I added braces to the exponents inside `<m>` tags because when the exponent was 10, the latex was previously rendering 1 in the exponent and 0 not in the exponent.  