### PR TITLE
remove troublesome fillin tag in proteus limits question

### DIFF
--- a/source/proteus/proteus-1-2.xml
+++ b/source/proteus/proteus-1-2.xml
@@ -57,7 +57,10 @@
     </p>
     
     <p>
-      If the ant is at the point on the graph directly above <m>x=3</m> what is the ant's height?  In other words, what is the corresponding <m>y</m>-value, <m>y = f(3)</m>?  State your answer in the form <q><m>f(3) = <fillin characters="2" /></m></q>.
+      If the ant is at the point on the graph directly above <m>x=3</m> what is the ant's height?  In other words, what is the corresponding <m>y</m>-value, <m>y = f(3)</m>?  
+    </p>
+    <p>
+        <m>f(3) = </m>
     </p>
     </statement>
      <response />


### PR DESCRIPTION
Okay so this is to do with Vilma's request and this screenshot:

<img width="875" height="488" alt="image" src="https://github.com/user-attachments/assets/2096122a-e8a3-4bea-918c-2524e9aeec5b" />

It looks like the issue is that Runestone doesn't cope correctly with PreTeXt's fillin tag. 
The easy and short-term way to resolve this is to rewrite the question to avoid the fillin tag, which is what I've done here. 
Probably the correct way longer-term is to turn this into a doenet question instead.