### PR TITLE
Fixing some typos and putting the slope fields for each exercise into a single prefigure image

### DIFF
--- a/source/exercises/doenet/ez-3-2-D-4.doenetml
+++ b/source/exercises/doenet/ez-3-2-D-4.doenetml
@@ -18,9 +18,7 @@
   <selectFromSequence name = "c" from = "2" to = "8" step = "1" exclude="$a $b"/>
   <selectFromSequence name = "d" from = "2" to = "8" step = "1" exclude="$a $b $c"/>
   <selectFromSequence name = "k" from = "2" to = "8" step = "1" exclude="$a $b $c $d"/>
-  
-  <number name="y1">$z1</number>
-  
+
   <function name="f" symbolic="false" styleNumber="1">
     sin($a*x)
   </function>
@@ -33,39 +31,39 @@
     cos($c*x)
   </function>
   <derivative name="hP">$h</derivative>
-   
+
 </setup>
 
 <p>
   Evaluate each of the following limits.  Think carefully about whether or not L'Hopital's Rule applies.
 </p>
-  
+
 <p>
   <ol marker="a.">
     <li>
-      <p> 
+      <p>
         <m>\displaystyle \lim_{x \to 0} \frac{\sin($a x)}{$d x} = </m><answer allowedErrorInNumbers="0.01" allowedErrorIsAbsolute>$a/$d</answer>
       </p>
-    </li> 
+    </li>
     <li>
       <p>
         <m>\displaystyle \lim_{x \to 0} \frac{\cos($c x)}{$d x + $b} = </m><answer allowedErrorInNumbers="0.01" allowedErrorIsAbsolute>1/$b</answer>
       </p>
-    </li> 
+    </li>
     <li>
       <p>
         <m>\displaystyle \lim_{x \to 0} \frac{\sin($a x)}{\tan($b x)} = </m><answer allowedErrorInNumbers="0.01" allowedErrorIsAbsolute>$a/$b</answer>
       </p>
-    </li> 
+    </li>
     <li>
       <p>
-        <m>\displaystyle \lim_{x \to 0} \frac{\cos($k x) - 1}{$b x} = </m><answer allowedErrorInNumbers="0.01" allowedErrorIsAbsolute>$a/$d</answer>
+        <m>\displaystyle \lim_{x \to 0} \frac{\cos($k x) - 1}{$b x} = </m><answer allowedErrorInNumbers="0.01" allowedErrorIsAbsolute>0</answer>
       </p>
-    </li>  
+    </li>
     <li>
       <p>
         <m>\displaystyle \lim_{x \to 0} \frac{\sin($k x) - $k x}{$c x^3} = </m><answer allowedErrorInNumbers="0.01" allowedErrorIsAbsolute>-1*$k^3/(6*$c)</answer>
       </p>
-    </li>      
-  </ol>  
+    </li>
+  </ol>
 </p>  

--- a/source/exercises/doenet/ez-3-2-D-5.doenetml
+++ b/source/exercises/doenet/ez-3-2-D-5.doenetml
@@ -59,7 +59,7 @@
     </li>
     <li>
       <p>
-        <m>\displaystyle \lim_{x \to -\infty} \frac{<math simplify>$$h(x)</math>}{<math simplify>$$g(x)</math>} = </m><answer allowedErrorInNumbers="0.01" allowedErrorIsAbsolute><conditionalContent><sign>$m/$d</sign></conditionalContent>INF</answer>
+        <m>\displaystyle \lim_{x \to -\infty} \frac{<math simplify>$$h(x)</math>}{<math simplify>$$g(x)</math>} = </m><answer allowedErrorInNumbers="0.01" allowedErrorIsAbsolute><sign>$m/$d</sign>INF</answer>
       </p>
     </li>
     <li>
@@ -68,4 +68,4 @@
       </p>
     </li>
   </ol>
-</p>  
+</p>

--- a/source/exercises/doenet/ez-3-2-D-5.doenetml
+++ b/source/exercises/doenet/ez-3-2-D-5.doenetml
@@ -20,17 +20,15 @@
   <selectFromSequence name = "k" from = "-6" to = "8" step = "1" exclude="-1 0 1 $a $b $c $d"/>
   <selectFromSequence name = "m" from = "-6" to = "8" step = "1" exclude="-1 0 1 $a $b $c $d $k"/>
   <selectFromSequence name = "n" from = "-6" to = "8" step = "1" exclude="-1 0 1 $a $b $c $d $k $m"/>
-  <selectFromSequence name = "p" from = "-6" to = "8" step = "1" exclude="-1 0 1 $a $b $c $d $k $m $n"/>  
-  <selectFromSequence name = "q" from = "-6" to = "8" step = "1" exclude="-1 0 1 $a $b $c $d $k $m $n $p"/>    
-  
-  <number name="y1">$z1</number>
-  
+  <selectFromSequence name = "p" from = "-6" to = "8" step = "1" exclude="-1 0 1 $a $b $c $d $k $m $n"/>
+  <selectFromSequence name = "q" from = "-6" to = "8" step = "1" exclude="-1 0 1 $a $b $c $d $k $m $n $p"/>
+
   <function name="f" styleNumber="1">
     $a*x^3 - $b*x^2 + $c
   </function>
   <derivative name="fP">$f</derivative>
   <function name="g" styleNumber="2">
-    $d*x^3 + $k*x^2 - $m*x 
+    $d*x^3 + $k*x^2 - $m*x
   </function>
   <derivative name="gP">$g</derivative>
   <function name="h"  styleNumber="3">
@@ -40,34 +38,34 @@
   <function name="j"  styleNumber="4">
     $p*x^3 - $c
   </function>
-  
+
 </setup>
 
 <p>
   Evaluate each of the following limits.  If the limit is <q><m>+\infty</m></q>, enter <q>INF</q>; if the limit is <q><m>-\infty</m></q>, enter <q>-INF</q>; if the limit does not exist, enter <q>DNE</q>. Otherwise, enter the numerical value of the limit.
 </p>
-  
+
 <p>
   <ol marker="a.">
     <li>
-      <p> 
+      <p>
         <m>\displaystyle \lim_{x \to \infty} \frac{<math simplify>$$f(x)</math>}{<math simplify>$$g(x)</math>} = </m><answer allowedErrorInNumbers="0.01" allowedErrorIsAbsolute>$a/$d</answer>
       </p>
-    </li> 
+    </li>
     <li>
-      <p> 
+      <p>
         <m>\displaystyle \lim_{x \to -\infty} \frac{<math simplify>$$g(x)</math>}{<math simplify>$$h(x)</math>} = </m><answer allowedErrorInNumbers="0.01" allowedErrorIsAbsolute>0</answer>
       </p>
-    </li> 
+    </li>
     <li>
-      <p> 
-        <m>\displaystyle \lim_{x \to -\infty} \frac{<math simplify>$$h(x)</math>}{<math simplify>$$g(x)</math>} = </m><answer allowedErrorInNumbers="0.01" allowedErrorIsAbsolute>-INF</answer>
+      <p>
+        <m>\displaystyle \lim_{x \to -\infty} \frac{<math simplify>$$h(x)</math>}{<math simplify>$$g(x)</math>} = </m><answer allowedErrorInNumbers="0.01" allowedErrorIsAbsolute><conditionalContent><sign>$m/$d</sign></conditionalContent>INF</answer>
       </p>
-    </li> 
+    </li>
     <li>
-      <p> 
+      <p>
         <m>\displaystyle \lim_{x \to \infty} \frac{<math simplify>$$j(x)</math>}{<math simplify>$$f(x)</math>} = </m><answer allowedErrorInNumbers="0.01" allowedErrorIsAbsolute>$p/$a</answer>
       </p>
-    </li>     
-  </ol>  
+    </li>
+  </ol>
 </p>  

--- a/source/exercises/doenet/ez-7-2-D-2.doenetml
+++ b/source/exercises/doenet/ez-7-2-D-2.doenetml
@@ -25,31 +25,29 @@
 <ol marker="a.">
   <li>
     <p>
-      At each of the stated points, decide whether the slope of the solution curve that passes through the point has slope that is positive, negative, zero, or undefined.
+      At each of the stated points, decide whether the solution curve that passes through the point has slope that is positive, negative, zero, or undefined at the specified point.
     </p>
     <ol marker="i.">
       <li>
         <p>
           The slope of the solution that passes through <m>($a, $b)</m> is
-        </p>
-        <p>
-          <choiceInput name="ans1">
+          <answer><choiceInput name="ans1">
             <choice>positive</choice>
             <choice>negative</choice>
             <choice>zero</choice>
             <choice>undefined</choice>
-          </choiceInput><answer>
+          </choiceInput>
             <award>
-                <when>$ans1.selectedIndices=1 and 0.5*($a-$b) > 0   
+                <when>$ans1.selectedIndices=1 and 0.5*($a-$b) > 0
                 </when>
-              </award>  
-              <award>
-                <when>$ans1.selectedIndices=2 and 0.5*($a-$b) < 0 
-                </when> 
               </award>
               <award>
-                <when>$ans1.selectedIndices=3 and 0.5*($a-$b) = 0 
-                </when> 
+                <when>$ans1.selectedIndices=2 and 0.5*($a-$b) < 0
+                </when>
+              </award>
+              <award>
+                <when>$ans1.selectedIndices=3 and 0.5*($a-$b) = 0
+                </when>
               </award>
           </answer>
         </p>
@@ -57,89 +55,83 @@
       <li>
         <p>
           The slope of the solution that passes through <m>($a, <math simplify>-$b</math>)</m> is
-        </p>
-        <p>
-          <choiceInput name="ans2">
+          <answer><choiceInput name="ans2">
             <choice>positive</choice>
             <choice>negative</choice>
             <choice>zero</choice>
             <choice>undefined</choice>
-          </choiceInput><answer>
+          </choiceInput>
             <award>
-                <when>$ans2.selectedIndices=1 and 0.5*($a+$b) > 0   
+                <when>$ans2.selectedIndices=1 and 0.5*($a+$b) > 0
                 </when>
-              </award>  
-              <award>
-                <when>$ans2.selectedIndices=2 and 0.5*($a+$b) < 0 
-                </when> 
               </award>
               <award>
-                <when>$ans2.selectedIndices=3 and 0.5*($a+$b) = 0 
-                </when> 
+                <when>$ans2.selectedIndices=2 and 0.5*($a+$b) < 0
+                </when>
+              </award>
+              <award>
+                <when>$ans2.selectedIndices=3 and 0.5*($a+$b) = 0
+                </when>
               </award>
           </answer>
         </p>
-      </li> 
+      </li>
       <li>
         <p>
           The slope of the solution that passes through <m>(<math simplify>-$a</math>, $b)</m> is
-        </p>
-        <p>
-          <choiceInput name="ans3">
+          <answer><choiceInput name="ans3">
             <choice>positive</choice>
             <choice>negative</choice>
             <choice>zero</choice>
             <choice>undefined</choice>
-          </choiceInput><answer>
+          </choiceInput>
             <award>
-                <when>$ans3.selectedIndices=1 and 0.5*(-$a-$b) > 0   
+                <when>$ans3.selectedIndices=1 and 0.5*(-$a-$b) > 0
                 </when>
-              </award>  
-              <award>
-                <when>$ans3.selectedIndices=2 and 0.5*(-$a-$b) < 0 
-                </when> 
               </award>
               <award>
-                <when>$ans3.selectedIndices=3 and 0.5*(-$a-$b) = 0 
-                </when> 
+                <when>$ans3.selectedIndices=2 and 0.5*(-$a-$b) < 0
+                </when>
+              </award>
+              <award>
+                <when>$ans3.selectedIndices=3 and 0.5*(-$a-$b) = 0
+                </when>
               </award>
           </answer>
         </p>
-      </li> 
+      </li>
       <li>
         <p>
           The slope of the solution that passes through <m>($a, $a)</m> is
-        </p>
-        <p>
-          <choiceInput name="ans4">
+          <answer><choiceInput name="ans4">
             <choice>positive</choice>
             <choice>negative</choice>
             <choice>zero</choice>
             <choice>undefined</choice>
-          </choiceInput><answer>
+          </choiceInput>
             <award>
-                <when>$ans4.selectedIndices=1 and 0.5*($a-$a) > 0   
+                <when>$ans4.selectedIndices=1 and 0.5*($a-$a) > 0
                 </when>
-              </award>  
-              <award>
-                <when>$ans4.selectedIndices=2 and 0.5*($a-$a) < 0 
-                </when> 
               </award>
               <award>
-                <when>$ans4.selectedIndices=3 and 0.5*($a-$a) = 0 
-                </when> 
+                <when>$ans4.selectedIndices=2 and 0.5*($a-$a) < 0
+                </when>
+              </award>
+              <award>
+                <when>$ans4.selectedIndices=3 and 0.5*($a-$a) = 0
+                </when>
               </award>
           </answer>
         </p>
-      </li> 
+      </li>
     </ol>
   </li>
   <li>
     <p>
-      Now, consider the solution to the differential equation that passes through the point <m>($a, <math simplify>$a-2</math>)</m>.  Based on the behavior of the solution's graph, what do you think is the formula of the solution?  Enter your formula as a function of <m>t</m>. 
+      Now, consider the solution to the differential equation that passes through the point <m>($a, <math simplify>$a-2</math>)</m>.  Based on the behavior of the solution's graph, what do you think is the formula of the solution?  Enter your formula as a function of <m>t</m>.
     </p>
     <p>
-      <m>y = </m><mathInput name="soln"/><answer><award><when>$soln=t-2</when></award></answer>
+      <answer><label><m>y=</m></label>t-2</answer>
     </p>
   </li>
 </ol>

--- a/source/exercises/doenet/ez-7-2-D-6.doenetml
+++ b/source/exercises/doenet/ez-7-2-D-6.doenetml
@@ -13,30 +13,30 @@
 <!-- **********************************************************************-->
 
 <p>
-  Match each of the four slope fields above <mdash/> A, B, C, and D <mdash/> to their corresonding differential equation from among the following choices.  For each equation below, enter either the corresponding letter (A, B, C, or D) or <q>none</q> if there is no slope field that matches the equation.
+  Match each of the four slope fields above <mdash/> A, B, C, and D <mdash/> to their corresonding differential equation from among the following choices.  For each equation below, choose either the corresponding letter (A, B, C, or D) or <q>none</q> if there is no slope field that matches the equation.
 </p>
 
 <p>
-  <textInput name="E3"/>: <m>\frac{dy}{dt} = 0.5 \frac{t}{y}</m>
-</p> 
+  <choiceInput name="E3" inline><choice>?</choice><choice>A</choice><choice>B</choice><choice>C</choice><choice>D</choice><choice>none</choice></choiceInput><m>\hspace{.1in} \frac{dy}{dt} = 0.5 \frac{t}{y} </m>
+</p>
 <p>
-  <textInput name="E1"/>: <m>\frac{dy}{dt} = -0.5(t-y)</m>
-</p> 
+  <choiceInput name="E1" inline><choice>?</choice><choice>A</choice><choice>B</choice><choice>C</choice><choice>D</choice><choice>none</choice></choiceInput><m> \hspace{.1in} \frac{dy}{dt} = -0.5(t-y)</m>
+</p>
 <p>
-  <textInput name="E5"/>: <m>\frac{dy}{dt} = 0.5(t-y)</m>
-</p> 
+  <choiceInput name="E5" inline><choice>?</choice><choice>A</choice><choice>B</choice><choice>C</choice><choice>D</choice><choice>none</choice></choiceInput><m> \hspace{.1in} \frac{dy}{dt} = 0.5(t-y) </m>
+</p>
 <p>
-  <textInput name="E6"/>: <m>\frac{dy}{dt} = 0.5(t+y)</m>
-</p> 
+  <choiceInput name="E6" inline><choice>?</choice><choice>A</choice><choice>B</choice><choice>C</choice><choice>D</choice><choice>none</choice></choiceInput><m>\hspace{.1in} \frac{dy}{dt} = 0.5(t+y) </m>
+</p>
 <p>
-  <textInput name="E2"/>: <m>\frac{dy}{dt} = 0.5 t y</m>
-</p> 
+  <choiceInput name="E2" inline><choice>?</choice><choice>A</choice><choice>B</choice><choice>C</choice><choice>D</choice><choice>none</choice></choiceInput><m>\hspace{.1in}\frac{dy}{dt} = 0.5 t y </m>
+</p>
 <p>
-  <textInput name="E4"/>: <m>\frac{dy}{dt} = -0.5 t y</m>
-</p> 
+  <choiceInput name="E4" inline><choice>?</choice><choice>A</choice><choice>B</choice><choice>C</choice><choice>D</choice><choice>none</choice></choiceInput><m>\hspace{.1in} \frac{dy}{dt} = -0.5 t y </m>
+</p>
 
 <p>
   <answer matchPartial><award><when>
-    $E1=none and $E2=B and $E3=C and $E4=none and $E5=A and $E6=D
+    $E1.selectedIndices=6 and $E2.selectedIndices=3 and $E3.selectedIndices=4 and $E4.selectedIndices=6 and $E5.selectedIndices=2 and $E6.selectedIndices=5
   </when></award></answer>
 </p>

--- a/source/exercises/ez-7-2-D.xml
+++ b/source/exercises/ez-7-2-D.xml
@@ -18,182 +18,147 @@
 <exercise label="ez-7-2-doenet-1">
   <title>Finding equilibrium solutions to autonomous differential equations</title>
   <dynamic>
-    <statement>  
+    <statement>
       <interactive label="doe-int-ex-7-2-1" platform="doenetml">
-        <slate surface="doenetml">   
+        <slate surface="doenetml">
           <xi:include href="doenet/ez-7-2-D-1.doenetml" parse="text"/>
-        </slate>   
-      </interactive>  
+        </slate>
+      </interactive>
     </statement>
   </dynamic>
-  <static/> 
-</exercise>      
+  <static/>
+</exercise>
 
 <exercise label="ez-7-2-doenet-2">
   <title>Interpreting solutions for a differential equation with a given slope field</title>
   <dynamic>
-    <statement> 
-        <figure xml:id="F-ez-7-2-doenet-2">
-            <caption>A slope field for a certain differential equation</caption>
-            <image width="35%">
-              <prefigure label="Fig-ez-7-2-doenet-2" xmlns="https://prefigure.org">
-                <diagram dimensions="(300,300)" margins="10">
-                <definition>f(t,y) = 0.5*(t-y)</definition>
-                <coordinates bbox="[-4,-4,4,4]">
-                    <grid-axes xlabel="t" ylabel="y"/>
-                    <slope-field function="f"/>
-                </coordinates>
-                </diagram>
-              </prefigure>
-            </image>
-        </figure>  
+    <statement>
+      <p><image width="50%">
+        <prefigure label="Fig-ez-7-2-doenet-2" xmlns="https://prefigure.org">
+          <diagram dimensions="(300,300)" margins="10">
+          <definition>f(t,y) = 0.5*(t-y)</definition>
+          <coordinates bbox="[-4,-4,4,4]">
+              <grid-axes xlabel="t" ylabel="y"/>
+              <slope-field function="f"/>
+          </coordinates>
+          </diagram>
+        </prefigure>
+      </image></p>
         <interactive label="doe-int-ex-7-2-2" platform="doenetml">
-          <slate surface="doenetml">   
+          <slate surface="doenetml">
             <xi:include href="doenet/ez-7-2-D-2.doenetml" parse="text"/>
-          </slate>   
-        </interactive>  
+          </slate>
+        </interactive>
     </statement>
   </dynamic>
-  <static/>     
-</exercise> 
+  <static/>
+</exercise>
 
 <exercise label="ez-7-2-doenet-3">
   <title>Identifying equilibrium solutions and their stability from slope fields</title>
   <dynamic>
-    <statement> 
-        <figure xml:id="F-ez-7-2-doenet-3">
-            <caption>Slope fields for two differential equations; at left, for differential equation (1); at right, for differential equation (2)</caption>
-            <sidebyside widths="40% 40%">
-            <image width="25%">
-              <prefigure label="Fig-ez-7-2-doenet-3a" xmlns="https://prefigure.org">
-                <diagram dimensions="(300,300)" margins="10">
-                    <definition>f(t,y) = 0.1*(y-1)*(y-5)</definition>
-                    <coordinates bbox="[-1,-1,8,8]">
-                        <grid-axes xlabel="t" ylabel="y"/>
-                        <slope-field function="f"/>
-                    </coordinates>
-                </diagram>
-              </prefigure>
-            </image>
-            <image width="25%">
-              <prefigure label="Fig-ez-7-2-doenet-3b" xmlns="https://prefigure.org">
-                <diagram dimensions="(300,300)" margins="10">
-                    <definition>f(t,y) = -0.1*(y-2)*(y-6)</definition>
-                    <coordinates bbox="[-1,-1,8,8]">
-                        <grid-axes xlabel="t" ylabel="y"/>
-                        <slope-field function="f"/>
-                    </coordinates>
-                </diagram>
-              </prefigure>
-            </image>           
-            </sidebyside>
-        </figure>  
+    <statement>
+        <p>
+          <image width="100%">
+            <prefigure label="Fig-ez-7-2-doenet-3" xmlns="https://prefigure.org">
+              <diagram dimensions="(650,300)" margins="10">
+                <definition>f(t,y) = 0.1*(y-1)*(y-5)</definition>
+                <coordinates bbox="[-1,-1,8,8]" destination="(10,10,290,290)">
+                    <grid-axes xlabel="t" ylabel="y"/>
+                    <slope-field function="f"/>
+                </coordinates>
+                <definition>f(t,y) = -0.1*(y-2)*(y-6)</definition>
+                <coordinates bbox="[-1,-1,8,8]" destination="(360,10,640,290)">
+                    <grid-axes xlabel="t" ylabel="y"/>
+                    <slope-field function="f"/>
+                </coordinates>
+              </diagram>
+            </prefigure>
+          </image>
+        </p>
         <interactive label="doe-int-ex-7-2-3" platform="doenetml">
-          <slate surface="doenetml">   
+          <slate surface="doenetml">
             <xi:include href="doenet/ez-7-2-D-3.doenetml" parse="text"/>
-          </slate>   
-        </interactive>  
+          </slate>
+        </interactive>
       </statement>
   </dynamic>
-  <static/> 
-</exercise> 
+  <static/>
+</exercise>
 
 <exercise label="ez-7-2-doenet-4">
   <title>Analyzing an autonomous differential equation <m>\frac{dy}{dt} = f(y)</m> from a graph of <m>\frac{dy}{dt}</m> as a function of <m>y</m></title>
   <dynamic>
-    <statement>  
+    <statement>
       <interactive label="doe-int-ex-7-2-4" platform="doenetml">
-        <slate surface="doenetml">   
+        <slate surface="doenetml">
           <xi:include href="doenet/ez-7-2-D-4.doenetml" parse="text"/>
-        </slate>   
-      </interactive>  
+        </slate>
+      </interactive>
     </statement>
   </dynamic>
-  <static/> 
-</exercise>   
+  <static/>
+</exercise>
 
 <exercise label="ez-7-2-doenet-5">
   <title>Analyzing equilibrium solutions in two different applied settings</title>
   <dynamic>
-    <statement>  
+    <statement>
       <interactive label="doe-int-ex-7-2-5" platform="doenetml">
-        <slate surface="doenetml">   
+        <slate surface="doenetml">
           <xi:include href="doenet/ez-7-2-D-5.doenetml" parse="text"/>
-        </slate>   
-      </interactive>  
+        </slate>
+      </interactive>
     </statement>
   </dynamic>
-  <static/> 
-</exercise>    
+  <static/>
+</exercise>
 
 <exercise label="ez-7-2-doenet-6">
   <title>Matching slope fields to differential equations</title>
   <dynamic>
-    <statement>  
-        <figure xml:id="F-ez-7-2-doenet-6">
-            <caption>Slope fields for four different differential equations: A, B, C, and D</caption>
-            <sidebyside widths="40% 40%">
-            <image width="35%">
-              <prefigure label="Fig-ez-7-2-doenet-5a" xmlns="https://prefigure.org">
-                <diagram dimensions="(300,300)" margins="10">
-                <definition>f(t,y) = 0.5*(t-y)</definition>
-                <coordinates bbox="[-4,-4,4,4]">
+    <statement>
+      <p>
+      <image width="80%">
+        <prefigure label="Fig-ez-7-2-doenet-6" xmlns="https://prefigure.org">
+           <diagram dimensions="(700,700)" margins="10">
+              <definition>f(t,y) = 0.5*(t-y)</definition>
+                <coordinates bbox="[-4,-4,4,4]" destination="(10,390,310,690)">
                     <grid-axes xlabel="t" ylabel="y"/>
                     <slope-field function="f"/>
-                    <label anchor="(3.5,3.5)" alignment="c" clear-background="yes" font-size="28">A</label>
+                    <label anchor="(0,-4.5)" alignment="c" clear-background="yes" font-size="18">A</label>
                 </coordinates>
-                </diagram>
-              </prefigure>
-            </image> 
-            <image width="35%">
-              <prefigure label="Fig-ez-7-2-doenet-5b" xmlns="https://prefigure.org">
-                <diagram dimensions="(300,300)" margins="10">
-                <definition>f(t,y) = 0.5*t*y</definition>
-                <coordinates bbox="[-4,-4,4,4]">
+              <definition>f(t,y) = 0.5*t*y</definition>
+                <coordinates bbox="[-4,-4,4,4]" destination="(390,390,690,690)">
                     <grid-axes xlabel="t" ylabel="y"/>
                     <slope-field function="f"/>
-                    <label anchor="(3.5,3.5)" alignment="c" clear-background="yes" font-size="28">B</label>
+                    <label anchor="(0,-4.5)" alignment="c" clear-background="yes" font-size="18">B</label>
                 </coordinates>
-                </diagram>
-              </prefigure>
-            </image>           
-            </sidebyside>
-          <sidebyside widths="40% 40%">
-            <image width="35%">
-              <prefigure label="Fig-ez-7-2-doenet-5c" xmlns="https://prefigure.org">
-                <diagram dimensions="(300,300)" margins="10">
-                <definition>f(t,y) = 0.5*t/y</definition>
-                <coordinates bbox="[-4,-4,4,4]">
+              <definition>f(t,y) = 0.5*t/y</definition>
+                <coordinates bbox="[-4,-4,4,4]" destination="(10,20,310,320)">
                     <grid-axes xlabel="t" ylabel="y"/>
                     <slope-field function="f"/>
-                    <label anchor="(3.5,3.5)" alignment="c" clear-background="yes" font-size="28">C</label>
+                    <label anchor="(0,-4.5)" alignment="c" clear-background="yes" font-size="18">C</label>
                 </coordinates>
-                </diagram>
-              </prefigure>
-            </image> 
-            <image width="35%">
-              <prefigure label="Fig-ez-7-2-doenet-5d" xmlns="https://prefigure.org">
-                <diagram dimensions="(300,300)" margins="10">
-                <definition>f(t,y) = 0.5*(t+y)</definition>
-                <coordinates bbox="[-4,-4,4,4]">
+              <definition>f(t,y) = 0.5*(t+y)</definition>
+                <coordinates bbox="[-4,-4,4,4]" destination="(390,20,690,320)">
                     <grid-axes xlabel="t" ylabel="y"/>
                     <slope-field function="f"/>
-                    <label anchor="(3.5,3.5)" alignment="c" clear-background="yes" font-size="28">D</label>
+                    <label anchor="(0,-4.5)" alignment="c" clear-background="yes" font-size="18">D</label>
                 </coordinates>
-                </diagram>
-              </prefigure>
-            </image>           
-            </sidebyside>
-        </figure>  
+            </diagram>
+          </prefigure>
+        </image>
+      </p>
         <interactive label="doe-int-ex-7-2-6" platform="doenetml">
-          <slate surface="doenetml">   
+          <slate surface="doenetml">
             <xi:include href="doenet/ez-7-2-D-6.doenetml" parse="text"/>
-          </slate>   
-        </interactive>  
+          </slate>
+        </interactive>
     </statement>
   </dynamic>
-  <static/> 
-</exercise> 
+  <static/>
+</exercise>
 
 
   <exercise permid="OvE">
@@ -531,7 +496,7 @@
             <p permid="yvI">
               <m>
 				\frac{dP}{dt} = g(P) = P(6-P)-1
-			</m> 
+			</m>
 			; the equilibrium at <m>P\approx 0.172</m> is unstable; the equilibrium at <m>P \approx 5.83</m> is stable.
             </p>
           </li>
@@ -724,7 +689,7 @@
             <p permid="YNF">
               For positive <m>y</m> near <m>0</m>,
               <m>M(y) = \frac{y}{2+y} \approx 0</m>;
-              for large values of <m>y</m>,  
+              for large values of <m>y</m>,
               <m>M(y) = \frac{y}{2+y} \approx 1</m>.
             </p>
           </li>
@@ -761,13 +726,13 @@
               On their own,
               the mice add <m>20y</m> thousand mice per year to their total population.
               With <m>C</m> cats present,
-              the cats now remove 
+              the cats now remove
               <m>
               M(y) = C\frac{y}{2+y}
               </m>
               thousand mice per year.
               By taking both the rates at which mice are added and removed from the population into account,
-              we find the 
+              we find the
               updated differential equation
               <me permid="Zxz">
                 \frac{dy}{dt} = 20y - C\frac{y}{2+y}
@@ -778,7 +743,7 @@
             <p permid="JEH">
               For positive <m>y</m> near <m>0</m>,
               <m>M(y) = \frac{y}{2+y} \approx 0</m>;
-              for large values of <m>y</m>,  
+              for large values of <m>y</m>,
               <m>M(y) = \frac{y}{2+y} \approx 1</m>.
               This means that a single cat can remove about <m>1</m> thousand mice per year from the population when the mice population is large.
             </p>

--- a/source/previews/doenet/PA-3-2-D.doenetml
+++ b/source/previews/doenet/PA-3-2-D.doenetml
@@ -21,7 +21,7 @@
   <function name="g">x^2-1</function>
   <derivative name="gP">$g</derivative>
   <function name="h">(x^5+x-2)/(x^2-1)</function>
-</setup>  
+</setup>
 
   <p>
     Let <m>h</m> be the function given by <m>h(x) = \frac{x^5 + x - 2}{x^2 - 1}</m>.
@@ -40,9 +40,9 @@
          <choice>all real numbers except 1</choice>
          <choice credit="1">all real numbers except 1 and -1</choice>
          <choice>all real numbers except 2</choice>
-       </choiceInput></answer>.  
-     </p>  
-   </li> 
+       </choiceInput></answer>.
+     </p>
+   </li>
    <li>
       <p>
         If we try to evaluate <m>\displaystyle\lim_{x \to 1} \frac{x^5 + x - 2}{x^2 - 1}</m> by simply letting <m>x \to 1</m> in both the numerator and denominator, we get an indeterminate form because of two important facts:
@@ -50,23 +50,23 @@
           <li>
             <p>
               as <m>x \to 1</m>, we see that <m>(x^5 + x - 2) \to</m> <answer name="ans1">0</answer>
-            </p>  
+            </p>
           </li>
           <li>
             <p>
               as <m>x \to 1</m>, we see that <m>(x^2 - 1) \to</m> <answer name="ans2">0</answer>
-            </p> 
+            </p>
           </li>
-        </ul> 
-       </p>  
+        </ul>
+       </p>
         <p hide="not $Bsolved">
           This shows that <m>\displaystyle\lim_{x \to 1} \frac{x^5 + x - 2}{x^2 - 1}</m> is indeterminate and has form <m>\frac{0}{0}</m>.
-        </p>  
-     
-   </li> 
+        </p>
+
+   </li>
    <li>
       <p>
-        Next we will investigate the behavior of both the numerator and denominator of <m>h</m> near the point where <m>x = 1</m>.  
+        Next we will investigate the behavior of both the numerator and denominator of <m>h</m> near the point where <m>x = 1</m>.
       </p>
       <p>
         Let <m>f(x) = x^5 + x - 2</m> and <m>g(x) = x^2 - 1</m>.  Find the local linearizations of <m>f</m> and <m>g</m> at <m>a = 1</m>, and call these functions <m>L_f(x)</m> and <m>L_g(x)</m>, respectively.
@@ -75,9 +75,9 @@
         <m>L_f(x) = </m><answer>$$f(1) + $$fP(1)(x-1)</answer>
       </p>
      <p>
-        <m>L_f(x) = </m><answer>$$g(1) + $$gP(1)(x-1)</answer>
+        <m>L_g(x) = </m><answer>$$g(1) + $$gP(1)(x-1)</answer>
       </p>
-   </li> 
+   </li>
    <li>
       <p>
         Next, we observe that since <m>f(x)</m> <answer><choiceInput inline>
@@ -94,7 +94,7 @@
          <choice credit="1">is approximately equal to</choice>
        </choiceInput></answer> <m>\frac{L_f(x)}{L_g(x)}</m> for <m>x</m> near <m>a = 1</m>.
       </p>
-   </li> 
+   </li>
     <li>
       <p>
         Using your work from (c), evaluate
@@ -105,7 +105,7 @@
       <p>
           <m>\displaystyle \lim_{x \to 1} \frac{L_f(x)}{L_g(x)} = </m><answer allowedErrorInNumbers="0.001" allowedErrorIsAbsolute>3</answer>.
       </p>
-   </li> 
+   </li>
     <li>
       <p>
         Complete the following table of values for  <m>h(x)</m> near <m>x = 1</m>, reporting your values to 5 decimal places of accuracy.
@@ -116,30 +116,30 @@
           <cell halign="center"><m>1.01</m></cell>
           <cell halign="center"><m>1.001</m></cell>
           <cell halign="center"><m>1.0001</m></cell>
-        </row>  
+        </row>
         <row>
           <cell halign="right"><m>h(x)</m>:</cell>
           <cell halign="center"><answer allowedErrorInNumbers="0.00001" allowedErrorIsAbsolute><award>$$h(1.01)</award></answer></cell>
           <cell halign="center"><answer allowedErrorInNumbers="0.00001" allowedErrorIsAbsolute><award>$$h(1.001)</award></answer></cell>
           <cell halign="center"><answer allowedErrorInNumbers="0.00001" allowedErrorIsAbsolute><award>$$h(1.0001)</award></answer></cell>
-        </row> 
+        </row>
         <row>
           <cell halign="right"><m>x</m>:</cell>
           <cell halign="center"><m>0.99</m></cell>
           <cell halign="center"><m>0.999</m></cell>
           <cell halign="center"><m>0.9999</m></cell>
-        </row>  
+        </row>
         <row>
           <cell halign="right"><m>h(x)</m>:</cell>
           <cell halign="center"><answer allowedErrorInNumbers="0.00001" allowedErrorIsAbsolute><award>$$h(0.99)</award></answer></cell>
           <cell halign="center"><answer allowedErrorInNumbers="0.00001" allowedErrorIsAbsolute><award>$$h(0.999)</award></answer></cell>
           <cell halign="center"><answer allowedErrorInNumbers="0.00001" allowedErrorIsAbsolute><award>$$h(0.9999)</award></answer></cell>
-        </row> 
-      </tabular> 
+        </row>
+      </tabular>
 
 <!--      <p><m><math displayDecimals="6"> $$h(0.99)</math></m></p> -->
-      
-   </li> 
+
+   </li>
     <li>
       <p>
         Based on your work in (e) and (f), what do you think is the value of <m>\lim_{x \to 1} h(x)</m>?
@@ -147,7 +147,7 @@
       <p>
         The value of <m>\lim_{x \to 1} h(x) = </m><answer>3</answer>.
       </p>
-    </li> 
+    </li>
   </ol>
-</p>  
-         
+</p>
+

--- a/source/previews/doenet/PA-7-3-D.doenetml
+++ b/source/previews/doenet/PA-7-3-D.doenetml
@@ -52,9 +52,9 @@
       </li>
       <li>
         <p>
-          Use the point <mathInput disabled>$point</mathInput> and
-          slope <mathInput disabled>$slope</mathInput> that you've found to find the equation
-          of the line tangent to the solution at <m>t=0</m>.  Be sure to write the tangent line equation as a function of <m>t</m>.
+          Use the point <mathInput disabled><conditionalContent condition="$point.creditAchieved=1">$point</conditionalContent></mathInput> and
+          slope <mathInput minWidth="30" disabled><conditionalContent condition="$slope.creditAchieved=1">$slope</conditionalContent></mathInput> that you've found above to write the equation
+          of the line tangent to the solution <m>y(t)</m> at <m>t=0</m>.  Be sure to write the tangent line equation as a function of <m>t</m>.
         </p>
         <p>
           <m>y=</m><answer name="approx0Exp">t/2</answer>
@@ -115,10 +115,10 @@
 
       <li>
         <p>
-          It turns out that the given initial value problem, 
+          It turns out that the given initial value problem,
           <me>
             \frac{dy}{dt} = \frac12 (y + 1), \ y(0) = 0,
-          </me> 
+          </me>
           has a solution
           of the form <m>y=ke^{t/2} - 1</m>.
         </p>
@@ -127,7 +127,7 @@
           <m>k</m>?
         </p>
         <p>
-          <m>k=</m><mathInput name="kEntered"/><answer name="kExp"><award><when>$kExp=1</when></award></answer>
+          <answer name="kEntered"><label><m>k=</m></label>1</answer>
         </p>
 
       </li>
@@ -135,11 +135,11 @@
       <!--
       <li>
         <setup>
-          <conditionalContent name="nextStep" condition="$kExp.creditAchieved = 1"> 
+          <conditionalContent name="nextStep" condition="$kExp.creditAchieved = 1">
             <math name="correctkEntered" extend="$kEntered.value"/>
             <math name="IVPsoln" simplify>$correctkEntered.value*e^(t/2) - 1</math>
           </conditionalContent>
-        </setup>      
+        </setup>
         <p>
           Then verify that
           <m>y=</m><mathInput disabled><math simplify>$k e^(t/2) - 1</math></mathInput>


### PR DESCRIPTION
I experienced some weirdness with generating the prefigure images that I'll post on -dev about eventually.  The images didn't seem to generate when inside the dynamic/static setup.  I commented those lines out, generated prefigure for the target, then uncommented them so that they were back inside of the dynamic/static setup, and then everything is fine.  Just a heads up for when you try to build with these changes!